### PR TITLE
Correct paths of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Here is the full list of all available variables:
 	let:patchName <!-- type: string - the name of the patch file -->
 	let:dependencyFileCorrected <!-- type: ExternalDataInfo[] - represents the json with dependencies of the patch, check RNBO js documentation -->
 	let:parameters <!-- type: Parameter[] - an array containing all RNBO parameters, check RNBO js documentation -->
-	let:context <!-- type: AudioContext - the device object, check RNBO js documentation -->
+	let:context <!-- type: AudioContext - the audio context, see https://developer.mozilla.org/Web/API/AudioContext -->
 	let:inports <!-- type: MessageInfo[] - an array of objects containing info on each message inlet -->
 	let:inlets <!-- type: signalPort[] - an array of objects containing info on each signal inlet -->
 	let:outports <!-- type: MessageInfo[] - an array of objects containing info on each message outlet -->

--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ This is enough to start running the RNBO patch in your Sveltekit project. It wil
 
 ## opening different patches
 
-to open different RNBO patch exports, give the exports different names, and use the built-in `path` prop in the RNBO components to open them:
+to open different RNBO patch exports, export them to different directories, and use the built-in `dir` prop in the RNBO components to open them:
 
 ```svelte
 <script>
 	import { RNBO } from 'rnbokit';
 </script>
 
-<RNBO path="patch.export.json" />
-<RNBO path="patch2.export.json" />
+<RNBO dir="/src/RNBO/Patch1" />
+<RNBO dir="/src/RNBO/Patch2" />
 ```
 
 ## extending with custom slots
 
-You can customize how parameters or messages are handled by adding your own components in the RNBO tag. You can pass information from the RNBO component down to the child components by using Svelte's `let:` syntax. Some available objects are the `patcher` file (IPatcher), `dependencies` (IDependencies) `context` (AudioContext), `device` (Device), or `parameters` (Parameter[]). You can find more information on these in the [RNBO JS documentation](https://rnbo.cycling74.com/js)
+You can customize how parameters or messages are handled by adding your own components in the RNBO tag. You can pass information from the RNBO component down to the child components by using Svelte's `let:` syntax. Some available objects are the `patcher` file (IPatcher), `dependencyFileCorrected` (ExternalDataInfo[]), `context` (AudioContext), `device` (Device), or `parameters` (Parameter[]). You can find more information on these in the [RNBO JS documentation](https://rnbo.cycling74.com/js).
 
 ```svelte
 <script>
@@ -72,7 +72,7 @@ You can customize how parameters or messages are handled by adding your own comp
 </script>
 
 <RNBO let:parameters let:patcher>
-	<p>used Max version: {patcher.meta.maxversion}</p>
+	<p>used Max version: {patcher.desc.meta.maxversion}</p>
 	{#each parameters as parameter}
 		<!-- create custom components -->
 		<p>{parameter.name}</p>
@@ -91,13 +91,18 @@ Here is the full list of all available variables:
 </script>
 
 <RNBO let:patcher <!-- type: IPatcher - represents the json exported from Max -->
-	let:device <!-- type: Device          - the device object, check RNBO js documentation  -->
-	let:dependencies <!-- type: IDependencies - represents the json with dependencies of the patch, check RNBO js documentation -->
-	let:parameters <!-- type: Parameter[]     - an array containing all RNBO parameters, check RNBO js documentation -->
-	let:midiInports <!-- type: Array<Number>   - an array representing each port as an index number -->
-	let:inlets <!-- type: MessageInfo[]   - an array of objects containing info on each signal inlet- -->
-	let:inports <!-- type: MessageInfo[]   - an array of objects containing info on each message inlet -->
-	let:outports <!-- type: MessageInfo[]   - an array of objects containing info on each message outlet -->
+	let:device <!-- type: Device - the device object, check RNBO js documentation -->
+	let:dir <!-- type: string - the directory the patch was exported to -->
+	let:patchName <!-- type: string - the name of the patch file -->
+	let:dependencyFileCorrected <!-- type: ExternalDataInfo[] - represents the json with dependencies of the patch, check RNBO js documentation -->
+	let:parameters <!-- type: Parameter[] - an array containing all RNBO parameters, check RNBO js documentation -->
+	let:context <!-- type: AudioContext - the device object, check RNBO js documentation -->
+	let:inports <!-- type: MessageInfo[] - an array of objects containing info on each message inlet -->
+	let:inlets <!-- type: signalPort[] - an array of objects containing info on each signal inlet -->
+	let:outports <!-- type: MessageInfo[] - an array of objects containing info on each message outlet -->
+	let:outlets <!-- type: signalPort[] - an array of objects containing info on each signal outlet -->
+	let:midiInports <!-- type: Array<Number> - an array representing each midiInport as an index number -->
+	let:midiOutports <!-- type: Array<Number> - an array representing each midiOutport as an index number -->
 	>
 	<!-- do something with it here -->
 </RNBO>
@@ -196,10 +201,10 @@ The default styling is done with the internal RNBO.css stylesheet. If you want t
 Here is what it could look like if you'd recreate the RNBO component's default slot, for inspiration:
 
 ```svelte
-<RNBO let:path let:device let:midiInports let:inlets let:inports let:parameters let:outports>
+<RNBO let:patchName let:device let:midiInports let:inlets let:inports let:parameters let:outports>
 	<div class="RNBOsection">
 		<!-- use the json file name as header -->
-		<h1>{path.split('/').pop().replace('.json', '')}</h1>
+		<h1>{patchName}</h1>
 
 		<!-- create input for each MIDI input port -->
 		{#if midiInports.length > 0}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
 	"types": "./dist/index.d.ts",
 	"type": "module",
 	"dependencies": {
-		"@rnbo/js": "^1.1.2"
+		"@rnbo/js": "^1.1.2",
+		"@types/path-browserify": "^1.0.0",
+		"path-browserify": "^1.0.1"
 	},
 	"repository": {
 		"type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,19 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@rnbo/js':
     specifier: ^1.1.2
     version: 1.1.2
+  '@types/path-browserify':
+    specifier: ^1.0.0
+    version: 1.0.0
+  path-browserify:
+    specifier: ^1.0.1
+    version: 1.0.1
 
 devDependencies:
   '@playwright/test':
@@ -503,6 +513,10 @@ packages:
   /@types/node@20.3.1:
     resolution: {integrity: sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==}
     dev: true
+
+  /@types/path-browserify@1.0.0:
+    resolution: {integrity: sha512-XMCcyhSvxcch8b7rZAtFAaierBYdeHXVvg2iYnxOV0MCQHmPuRRmGZPFDRzPayxcGiiSL1Te9UIO+f3cuj0tfw==}
+    dev: false
 
   /@types/pug@2.0.6:
     resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
@@ -1407,6 +1421,10 @@ packages:
       no-case: 3.0.4
       tslib: 2.5.3
     dev: true
+
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}

--- a/src/lib/RNBO.svelte
+++ b/src/lib/RNBO.svelte
@@ -35,7 +35,7 @@
 	let patcher = undefined;
 
 	/** @type {import ('@rnbo/js').ExternalDataInfo[]|undefined} */
-	let dependencyFile = undefined;
+	let dependencyFileCorrected = undefined;
 
 	/** @type {import ('@rnbo/js').Parameter[]} */
 	export let parameters = [];
@@ -72,9 +72,9 @@
 
 		if (patcher && context) {
 			//import the dependency json dynamically!
-			dependencyFile = (await import(/* @vite-ignore */ dependencies)).default;
+			const dependencyFile = (await import(/* @vite-ignore */ dependencies)).default;
 
-			const dependencyFileCorrected = dependencyFile.map((dependency) => {
+			dependencyFileCorrected = dependencyFile.map((dependency) => {
 				if ('file' in dependency) {
 					const newFile = path.join(dir, dependency.file);
 					return Object.assign({}, dependency, { file: newFile });
@@ -136,7 +136,7 @@
 			{device}
 			{dir}
 			{patchName}
-			{dependencies}
+			{dependencyFileCorrected}
 			{parameters}
 			{context}
 			{inports}

--- a/src/lib/RNBO.svelte
+++ b/src/lib/RNBO.svelte
@@ -1,7 +1,7 @@
 <script>
 	import './RNBO.css';
 	import { onMount } from 'svelte';
-	import { createDevice } from '@rnbo/js';
+	import { BaseDevice, createDevice } from '@rnbo/js';
 	import RNBOParam from './RNBOcomponents/RNBOParam.svelte';
 	import RNBOOutport from './RNBOcomponents/RNBOOutport.svelte';
 	import RNBOInport from './RNBOcomponents/RNBOInport.svelte';
@@ -75,11 +75,11 @@
 			const dependencyFile = (await import(/* @vite-ignore */ dependencies)).default;
 
 			dependencyFileCorrected = dependencyFile.map((dependency) => {
-				if ('file' in dependency) {
-					const newFile = path.join(dir, dependency.file);
-					return Object.assign({}, dependency, { file: newFile });
+				if (BaseDevice.bufferDescriptionHasRemoteURL(dependency)) {
+					return dependency;
 				}
-				return dependency;
+				const newFile = path.join(dir, dependency.file);
+				return Object.assign({}, dependency, { file: newFile });
 			});
 
 			device = await createDevice({ context, patcher });

--- a/src/lib/RNBO.svelte
+++ b/src/lib/RNBO.svelte
@@ -77,9 +77,7 @@
 			const dependencyFileCorrected = dependencyFile.map((dependency) => {
 				if ('file' in dependency) {
 					const newFile = path.join(dir, dependency.file);
-					return Object.assign({}, dependency, {
-						file: newFile
-					});
+					return Object.assign({}, dependency, { file: newFile });
 				}
 				return dependency;
 			});


### PR DESCRIPTION
After an export from RNBO, we have only relative paths in the `dependencies.json` file. We have to prepend them by `/src/RNBO` (in general).

Since the file name is always `dependencies.json`, we do not need to use props for the dependencies path, but for the path where the patch, the dependencies file, and the dependencies lie.

Therefore, I split up the `path` variable into a `dir` and a `patchName` variable.